### PR TITLE
Load up to 300 projects fron the openclimateaction endpoint

### DIFF
--- a/data/ecosystems.ts
+++ b/data/ecosystems.ts
@@ -1,7 +1,7 @@
 import type { Project } from "@/types/apiTypes";
 
 export async function GetAllProjects() {
-  const response = await fetch("https://ost.ecosyste.ms/api/v1/issues/openclimateaction");
+  const response = await fetch("https://ost.ecosyste.ms/api/v1/issues/openclimateaction?per_page=300");
   const data = (await response.json()) as Project[];
   return data;
 }


### PR DESCRIPTION
There are over 100 projects in the list now, we can avoid having to implement pagination by loading them all in one go