### PR TITLE
Feat: sort projects based on download numbers

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -2,7 +2,7 @@ import { RepositorySortOrder } from "./types/types";
 
 export const REPOSITORY_SORT_OPTIONS = [
   RepositorySortOrder.NEW_ISSUES,
-  RepositorySortOrder.LEAST_STARS,
+  RepositorySortOrder.MOST_DOWNLOADS,
   RepositorySortOrder.MOST_STARS,
   RepositorySortOrder.NONE
 ];

--- a/context/AppDataContext.tsx
+++ b/context/AppDataContext.tsx
@@ -97,9 +97,9 @@ const AppDataProvider = ({ children }: { children: React.ReactNode }) => {
       });
     }
 
-    if (sortOrder === RepositorySortOrder.LEAST_STARS) {
+    if (sortOrder === RepositorySortOrder.MOST_DOWNLOADS) {
       updatedRepositories = [...allRepositories].sort((currentRepository, nextRepository) => {
-        return currentRepository.stars - nextRepository.stars;
+        return nextRepository.monthly_downloads - currentRepository.monthly_downloads;
       });
     }
 

--- a/data/index.ts
+++ b/data/index.ts
@@ -29,7 +29,17 @@ const main = async () => {
   );
   try {
     const repositories = (await GetAllProjects()).map(
-      ({ id, name, url, language, category, has_new_issues, repository, issues }) => {
+      ({
+        id,
+        name,
+        url,
+        language,
+        category,
+        has_new_issues,
+        repository,
+        issues,
+        monthly_downloads
+      }) => {
         const { description, owner, stargazers_count, license, pushed_at, topics } = repository;
         return {
           id: id.toString(),
@@ -64,7 +74,8 @@ const main = async () => {
           tags: topics.map((t) => ({
             display: slugger(t),
             id: t
-          }))
+          })),
+          monthly_downloads: monthly_downloads
         } as Repository;
       }
     );

--- a/types/apiTypes.ts
+++ b/types/apiTypes.ts
@@ -13,6 +13,7 @@ export interface Project {
   sub_category: string;
   issues: Issue[];
   has_new_issues: boolean;
+  monthly_downloads: number;
 }
 
 export interface Issue {

--- a/types/types.ts
+++ b/types/types.ts
@@ -44,6 +44,7 @@ export interface Repository {
   url: string;
   tags?: Tag[];
   category: Tag;
+  monthly_downloads: number;
 }
 
 // Describes an Issue, which is a GitHub issue linked to a repository
@@ -65,7 +66,7 @@ export interface Label {
 
 export enum RepositorySortOrder {
   NEW_ISSUES = "New Issues",
-  LEAST_STARS = "By Least Stars",
+  MOST_DOWNLOADS = "By Most Downloads",
   MOST_STARS = "By Most Stars",
   NONE = "None"
 }


### PR DESCRIPTION
# Description

This PR replace the old sort method by least stars to most downloaded. Since this property was not found in the current structure of the project I had to update `Projects` and `Repository` types, now they have `monthly_downloads` property

# Fixes #22 

## Type of change

<!-- Please delete options that are not relevant. -->
- [x ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have testes only visually and with some logs on the console (I recommend to test it as well). I notice that we do not have a test environment for React (with testing library). I would recommend to add a setup and write tests for some of our features (I can do that by the way)
