### PR TITLE
Post Good First Issues to Bluesky and Mastodon - Resolves #48

### DIFF
--- a/.github/workflows/post-good-first-issues-mastodon-bluesky.yml
+++ b/.github/workflows/post-good-first-issues-mastodon-bluesky.yml
@@ -1,5 +1,4 @@
 name: Post Good First Issues to Bluesky and Mastodon
-
 on:
   issues:
     types:
@@ -12,7 +11,7 @@ jobs:
     steps:
       - name: Prepare Post
         env:
-          default_hashtags: " #climate #sustainability #opensource #opensustain #goodfirstissue #goodfirstissues #hacktoberfest #hacktoberfest2023"
+          default_hashtags: " #climate #sustainability #opensource #opensustain #goodfirstissue #goodfirstissues"
         run: |
           issue_title="${{ github.event.issue.title }}"
           issue_url="${{ github.event.issue.html_url }}"

--- a/.github/workflows/post-good-first-issues-mastodon-bluesky.yml
+++ b/.github/workflows/post-good-first-issues-mastodon-bluesky.yml
@@ -1,0 +1,42 @@
+name: Post Good First Issues to Bluesky and Mastodon
+
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  post_good_first_issue:
+    runs-on: ubuntu-latest
+    if: contains(github.event.label.name, 'good first issue')
+    steps:
+      - name: Prepare Post
+        env:
+          default_hashtags: " #climate #sustainability #opensource #opensustain #goodfirstissue #goodfirstissues #hacktoberfest #hacktoberfest2023"
+        run: |
+          issue_title="${{ github.event.issue.title }}"
+          issue_url="${{ github.event.issue.html_url }}"
+          issue_text="${{ github.event.issue.body }}"
+          post_message="$issue_title $issue_url $default_hashtags"
+          echo "post_message=$post_message" >> $GITHUB_ENV
+
+      - name: Send post to Bluesky
+        id: bluesky_post
+        uses: myConsciousness/bluesky-post@v5
+        with:
+          text: |
+            A new good first issue available for contribution: 
+            ${{ env.post_message }}
+          identifier: ${{ secrets.BLUESKY_IDENTIFIER }}
+          password: ${{ secrets.BLUESKY_PASSWORD }}
+
+      - name: Send post to Mastodon
+        id: mastodon_post
+        uses: cbrgm/mastodon-github-action@v2
+        with:
+          message: |
+            A new good first issue available for contribution: 
+            ${{ env.post_message }}
+          url: ${{ secrets.MASTODON_URL }}
+          access-token: ${{ secrets.MASTODON_ACCESS_TOKEN }}
+          visibility: "public"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically post "Good First Issues" to Bluesky and Mastodon when an issue is labeled as such. The main changes include the addition of a new YAML file to define the workflow and the steps to prepare and send the post to both platforms.

Configurations needed:
The following secrets must be added to the actions:

- **BLUESKY_IDENTIFIER** : the bot's bluesky identifier
- **BLUESKY_PASSWORD** : the bot's bluesky password
- **MASTODON_URL** : https://mastodon.social/ or any other used.
- **MASTODON_ACCESS_TOKEN** : the bot's mastodon account access token (create an application and add the access token)


New GitHub Actions workflow:

* [`.github/workflows/post-good-first-issues-mastodon-bluesky.yml`](diffhunk://#diff-b7bd1cd2133cf78688b3c4c4cc2fcc4f90bac2e1d887b19a422ff0583895b186R1-R41): Added a new workflow file to post "Good First Issues" to Bluesky and Mastodon. The workflow triggers on issues labeled with "good first issue" and includes steps to prepare the post message and send it to both platforms using respective GitHub Actions.