### PR TITLE
Feat: Post daily good first issues to Mastodon

### DIFF
--- a/.github/workflows/daily-post-good-first-issues-bluesky.yml
+++ b/.github/workflows/daily-post-good-first-issues-bluesky.yml
@@ -19,7 +19,7 @@ jobs:
           # response=$(curl -s https://ost.ecosyste.ms/api/v1/issues?recent=true)
 
           # For testing purposes, create a sample response as a single-line JSON
-           response='[{"project":{"name":"Project A","language":"Python"},"title":"Issue 1","url":"www.github.com/issue1","labels":["good first issue"]},{"project":{"name":"Project B","language":"JavaScript"},"title":"Issue 2","url":"www.github.com/issue2","labels":["good first issue"]}]'
+           response='[{"project":{"name":"Project A","language":"Python"},"title":"Issue 1","url":"www.github.com/issue1","labels":["good first issue"]},{"project":{"name":"Project B","language":"JavaScript"},"title":"Issue 2","url":"www.github.com/issue2","labels":["good first issue"]},{"project":{"name":"Project C","language":"Ruby"},"title":"Issue 3","url":"www.github.com/issue3","labels":["bug"]}]'
 
           echo "$response" > issues.json
 
@@ -36,7 +36,7 @@ jobs:
         env:
           default_hashtags: " #climate #sustainability #opensource #opensustain #goodfirstissue #goodfirstissues"
         run: |
-          jq -c --arg hashtags "$default_hashtags" '[.[] | {
+          jq -c --arg hashtags "$default_hashtags" '[.[] | select(.labels[] == "good first issue") | {
             message: (.title + " (" + .project.language + ") - " + .project.name + " " + .url + $hashtags)
           }]' issues.json > posts.json
 

--- a/.github/workflows/daily-post-good-first-issues-bluesky.yml
+++ b/.github/workflows/daily-post-good-first-issues-bluesky.yml
@@ -16,10 +16,10 @@ jobs:
         id: fetch_issues
         run: |
           # Uncomment the following line for production:
-          # response=$(curl -s https://ost.ecosyste.ms/api/v1/issues?recent=true)
+           response=$(curl -s https://ost.ecosyste.ms/api/v1/issues?recent=true)
 
           # For testing purposes, create a sample response as a single-line JSON
-           response='[{"project":{"name":"Project A","language":"Python"},"title":"Issue 1","url":"www.github.com/issue1","labels":["good first issue"]},{"project":{"name":"Project B","language":"JavaScript"},"title":"Issue 2","url":"www.github.com/issue2","labels":["good first issue"]},{"project":{"name":"Project C","language":"Ruby"},"title":"Issue 3","url":"www.github.com/issue3","labels":["bug"]}]'
+          # response='[{"project":{"name":"Project A","language":"Python"},"title":"Issue 1","url":"www.github.com/issue1","labels":["good first issue"]},{"project":{"name":"Project B","language":"JavaScript"},"title":"Issue 2","url":"www.github.com/issue2","labels":["good first issue"]},{"project":{"name":"Project C","language":"Ruby"},"title":"Issue 3","url":"www.github.com/issue3","labels":["bug"]}]'
 
           echo "$response" > issues.json
 

--- a/.github/workflows/daily-post-good-first-issues-bluesky.yml
+++ b/.github/workflows/daily-post-good-first-issues-bluesky.yml
@@ -90,5 +90,7 @@ jobs:
               -H "Authorization: Bearer $ACCESS_JWT" \
               -d "$post_payload"
 
+            echo "Waiting 5 seconds before the next post..."
+            sleep 5
           done < <(jq -c '.[]' posts.json)
           echo "✅ All posts sent to Bluesky."

--- a/.github/workflows/daily-post-good-first-issues-bluesky.yml
+++ b/.github/workflows/daily-post-good-first-issues-bluesky.yml
@@ -1,0 +1,89 @@
+name: Daily Post Good First Issues to BlueSky
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * *" # Runs daily at 12:00 PM UTC
+
+jobs:
+  post_good_first_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Fetch Good First Issues
+        id: fetch_issues
+        run: |
+          response=$(curl -s https://ost.ecosyste.ms/api/v1/issues?recent=true)
+          echo "$response" > issues.json
+
+      - name: Check if there are issues
+        run: |
+          if [[ ! -s issues.json ]] || [[ "$(jq length issues.json)" -eq 0 ]]; then
+            echo "No issues found. Exiting."
+            exit 0
+          fi
+          echo "Issues found. Proceeding."
+
+      - name: Prepare Posts
+        id: prepare_posts
+        env:
+          default_hashtags: " #climate #sustainability #opensource #opensustain #goodfirstissue #goodfirstissues"
+        run: |
+          jq -c --arg hashtags "$default_hashtags" '[.[] | {
+            message: (.title + " (" + .project.language + ") - " + .project.name + " " + .url + $hashtags)
+          }]' issues.json > posts.json
+
+          echo "Prepared posts:"
+          cat posts.json
+
+      - name: Send posts to Bluesky
+        env:
+          BLUESKY_IDENTIFIER: ${{ secrets.BLUESKY_IDENTIFIER }}
+          BLUESKY_PASSWORD: ${{ secrets.BLUESKY_PASSWORD }}
+        run: |
+          echo "Authenticating with Bluesky..."
+          auth_response=$(curl -s -X POST "https://bsky.social/xrpc/com.atproto.server.createSession" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "identifier": "'"$BLUESKY_IDENTIFIER"'",
+              "password": "'"$BLUESKY_PASSWORD"'"
+            }')
+
+          ACCESS_JWT=$(echo "$auth_response" | jq -r '.accessJwt')
+          DID=$(echo "$auth_response" | jq -r '.did')
+
+          if [[ -z "$ACCESS_JWT" || "$ACCESS_JWT" == "null" ]]; then
+            echo "❌ Failed to authenticate with Bluesky. Exiting."
+            exit 1
+          fi
+
+          echo "✅ Authenticated as $DID"
+
+          while IFS= read -r post; do
+            post_message=$(echo "$post" | jq -r '.message')
+            created_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+            post_payload=$(jq -n \
+              --arg repo "$DID" \
+              --arg text "$post_message" \
+              --arg createdAt "$created_at" \
+              '{
+                repo: $repo,
+                collection: "app.bsky.feed.post",
+                record: {
+                  "$type": "app.bsky.feed.post",
+                  text: $text,
+                  createdAt: $createdAt
+                }
+              }')
+
+            echo "Posting to Bluesky: $post_message"
+            curl -s -X POST "https://bsky.social/xrpc/com.atproto.repo.createRecord" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer $ACCESS_JWT" \
+              -d "$post_payload"
+
+          done < <(jq -c '.[]' posts.json)
+          echo "✅ All posts sent to Bluesky."

--- a/.github/workflows/daily-post-good-first-issues-bluesky.yml
+++ b/.github/workflows/daily-post-good-first-issues-bluesky.yml
@@ -19,7 +19,7 @@ jobs:
           # response=$(curl -s https://ost.ecosyste.ms/api/v1/issues?recent=true)
 
           # For testing purposes, create a sample response as a single-line JSON
-           response='[{"project":{"name":"Project A","language":"Python"},"title":"Issue 1","url":"www.github.com/issue1","labels":[{"name":"good first issue"}]},{"project":{"name":"Project B","language":"JavaScript"},"title":"Issue 2","url":"www.github.com/issue2","labels":[{"name":"good first issue"}]}]'
+           response='[{"project":{"name":"Project A","language":"Python"},"title":"Issue 1","url":"www.github.com/issue1","labels":["good first issue"]},{"project":{"name":"Project B","language":"JavaScript"},"title":"Issue 2","url":"www.github.com/issue2","labels":["good first issue"]}]'
 
           echo "$response" > issues.json
 

--- a/.github/workflows/daily-post-good-first-issues-bluesky.yml
+++ b/.github/workflows/daily-post-good-first-issues-bluesky.yml
@@ -15,7 +15,12 @@ jobs:
       - name: Fetch Good First Issues
         id: fetch_issues
         run: |
-          response=$(curl -s https://ost.ecosyste.ms/api/v1/issues?recent=true)
+          # Uncomment the following line for production:
+          # response=$(curl -s https://ost.ecosyste.ms/api/v1/issues?recent=true)
+
+          # For testing purposes, create a sample response as a single-line JSON
+           response='[{"project":{"name":"Project A","language":"Python"},"title":"Issue 1","url":"www.github.com/issue1","labels":[{"name":"good first issue"}]},{"project":{"name":"Project B","language":"JavaScript"},"title":"Issue 2","url":"www.github.com/issue2","labels":[{"name":"good first issue"}]}]'
+
           echo "$response" > issues.json
 
       - name: Check if there are issues

--- a/.github/workflows/daily-post-good-first-issues-mastodon.yml
+++ b/.github/workflows/daily-post-good-first-issues-mastodon.yml
@@ -1,0 +1,69 @@
+name: Daily Post Good First Issues to Mastodon
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * *" # Runs daily at 12:00 PM UTC
+
+jobs:
+  post_good_first_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Good First Issues
+        id: fetch_issues
+        run: |
+          # Uncomment the following line for production:
+           response=$(curl -s https://ost.ecosyste.ms/api/v1/issues?recent=true)
+
+          # For testing purposes, create a sample response as a single-line JSON
+          # response='[{"project":{"name":"Project A","language":"Python"},"title":"Issue 1","url":"www.github.com/issue1","labels":[{"name":"good first issue"}]},{"project":{"name":"Project B","language":"JavaScript"},"title":"Issue 2","url":"www.github.com/issue2","labels":[{"name":"good first issue"}]}]'
+
+          # Save to environment for next steps
+          echo "response=$response" >> $GITHUB_ENV
+
+      - name: Check if there are issues
+        id: check_issues
+        run: |
+          if [[ -z "${response}" ]] || [[ "${response}" == "[]" ]]; then
+            echo "No issues found. Exiting."
+            exit 0
+          fi
+          echo "Issues found. Proceeding."
+
+      - name: Prepare Posts
+        env:
+          default_hashtags: " #climate #sustainability #opensource #opensustain #goodfirstissue #goodfirstissues"
+        run: |
+          posts=$(echo "${response}" | jq -c '[.[] | {project_name: .project.name, title: .title, language: .project.language, url: .url}]')
+          echo "posts=$posts" >> $GITHUB_ENV
+
+          # Display the prepared posts for debugging
+          echo "Prepared posts:"
+          echo "$posts"
+
+      - name: Check if there are posts
+        run: |
+          if [[ -z "${posts}" ]] || [[ "${posts}" == "[]" ]]; then
+            echo "No posts to send. Exiting."
+            exit 0
+          fi
+          echo "Posts found. Proceeding."
+
+      - name: Send posts to Mastodon
+        env:
+          MASTODON_URL: ${{ secrets.MASTODON_URL }}
+          MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}
+          default_hashtags: " #climate #sustainability #opensource #opensustain #goodfirstissue #goodfirstissues"
+        run: |
+          echo "${posts}" | jq -c '.[]' | while read -r post; do
+            project_name=$(echo "$post" | jq -r '.project_name')
+            title=$(echo "$post" | jq -r '.title')
+            language=$(echo "$post" | jq -r '.language')
+            url=$(echo "$post" | jq -r '.url')
+            post_message="$title ($language) - $project_name $url $default_hashtags"
+
+            echo "Sending to Mastodon..."
+            curl -s -X POST "${MASTODON_URL}/api/v1/statuses" \
+              -H "Authorization: Bearer $MASTODON_ACCESS_TOKEN" \
+              -d "status=A new good first issue available for contribution: $post_message&visibility=public"
+          done

--- a/.github/workflows/daily-post-good-first-issues-mastodon.yml
+++ b/.github/workflows/daily-post-good-first-issues-mastodon.yml
@@ -16,7 +16,7 @@ jobs:
            response=$(curl -s https://ost.ecosyste.ms/api/v1/issues?recent=true)
 
           # For testing purposes, create a sample response as a single-line JSON
-          # response='[{"project":{"name":"Project A","language":"Python"},"title":"Issue 1","url":"www.github.com/issue1","labels":[{"name":"good first issue"}]},{"project":{"name":"Project B","language":"JavaScript"},"title":"Issue 2","url":"www.github.com/issue2","labels":[{"name":"good first issue"}]}]'
+          # response='[{"project":{"name":"Project A","language":"Python"},"title":"Issue 1","url":"www.github.com/issue1","labels":["good first issue"]},{"project":{"name":"Project B","language":"JavaScript"},"title":"Issue 2","url":"www.github.com/issue2","labels":["good first issue"]}]'
 
           # Save to environment for next steps
           echo "response=$response" >> $GITHUB_ENV

--- a/.github/workflows/daily-post-good-first-issues-mastodon.yml
+++ b/.github/workflows/daily-post-good-first-issues-mastodon.yml
@@ -13,10 +13,10 @@ jobs:
         id: fetch_issues
         run: |
           # Uncomment the following line for production:
-          # response=$(curl -s https://ost.ecosyste.ms/api/v1/issues?recent=true)
+           response=$(curl -s https://ost.ecosyste.ms/api/v1/issues?recent=true)
 
           # For testing purposes, create a sample response as a single-line JSON
-           response='[{"project":{"name":"Project A","language":"Python"},"title":"Issue 1","url":"www.github.com/issue1","labels":["good first issue"]},{"project":{"name":"Project B","language":"JavaScript"},"title":"Issue 2","url":"www.github.com/issue2","labels":["good first issue"]},{"project":{"name":"Project C","language":"Ruby"},"title":"Issue 3","url":"www.github.com/issue3","labels":["bug"]}]'
+          # response='[{"project":{"name":"Project A","language":"Python"},"title":"Issue 1","url":"www.github.com/issue1","labels":["good first issue"]},{"project":{"name":"Project B","language":"JavaScript"},"title":"Issue 2","url":"www.github.com/issue2","labels":["good first issue"]},{"project":{"name":"Project C","language":"Ruby"},"title":"Issue 3","url":"www.github.com/issue3","labels":["bug"]}]'
 
           # Save to environment for next steps
           echo "response=$response" >> $GITHUB_ENV

--- a/.github/workflows/daily-post-good-first-issues-mastodon.yml
+++ b/.github/workflows/daily-post-good-first-issues-mastodon.yml
@@ -13,10 +13,10 @@ jobs:
         id: fetch_issues
         run: |
           # Uncomment the following line for production:
-           response=$(curl -s https://ost.ecosyste.ms/api/v1/issues?recent=true)
+          # response=$(curl -s https://ost.ecosyste.ms/api/v1/issues?recent=true)
 
           # For testing purposes, create a sample response as a single-line JSON
-          # response='[{"project":{"name":"Project A","language":"Python"},"title":"Issue 1","url":"www.github.com/issue1","labels":["good first issue"]},{"project":{"name":"Project B","language":"JavaScript"},"title":"Issue 2","url":"www.github.com/issue2","labels":["good first issue"]}]'
+           response='[{"project":{"name":"Project A","language":"Python"},"title":"Issue 1","url":"www.github.com/issue1","labels":["good first issue"]},{"project":{"name":"Project B","language":"JavaScript"},"title":"Issue 2","url":"www.github.com/issue2","labels":["good first issue"]},{"project":{"name":"Project C","language":"Ruby"},"title":"Issue 3","url":"www.github.com/issue3","labels":["bug"]}]'
 
           # Save to environment for next steps
           echo "response=$response" >> $GITHUB_ENV
@@ -34,7 +34,7 @@ jobs:
         env:
           default_hashtags: " #climate #sustainability #opensource #opensustain #goodfirstissue #goodfirstissues"
         run: |
-          posts=$(echo "${response}" | jq -c '[.[] | {project_name: .project.name, title: .title, language: .project.language, url: .url}]')
+          posts=$(echo "${response}" | jq -c '[.[] | select(.labels[] == "good first issue") | {project_name: .project.name, title: .title, language: .project.language, url: .url}]')
           echo "posts=$posts" >> $GITHUB_ENV
 
           # Display the prepared posts for debugging


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate daily posts of "Good First Issues" to Mastodon. The workflow fetches issues, prepares them for posting, and sends them to a Mastodon instance using API integration.

### New Workflow Addition:
* [`.github/workflows/daily-post-good-first-issues-mastodon.yml`](diffhunk://#diff-5abf84aa886a00e0f4affbda87e299e6e129b5ebcdf58ff0dbf809276361c697R1-R69): Added a new workflow named "Daily Post Good First Issues to Mastodon." It runs daily at 12:00 PM UTC and includes steps to fetch "Good First Issues" from an API, prepare posts, and send them to Mastodon. The workflow uses environment variables and secrets for configuration and supports debugging by displaying prepared posts.